### PR TITLE
ABX-4298 update emission keypair sourcing

### DIFF
--- a/src/services/statistics.ts
+++ b/src/services/statistics.ts
@@ -57,7 +57,7 @@ function getUnbackedAccountKeys(connection: Connection) {
 
 export function getEmissionKeypair(connection: Connection): Keypair {
   const currentNetwork = getNetwork(connection)
-  const emissionSeedString = `${currentNetwork.networkPassphrase}emission`
+  const emissionSeedString = `${currentNetwork.networkPassphrase()}emission`
   const hash = createHash('sha256')
   hash.update(emissionSeedString)
 


### PR DESCRIPTION
* update emission keypair sourcing to correctly use network passphrase as function call when generating seed string for keypair