### PR TITLE
ABX-5951 Update to latest version of js-kinesis-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1926,9 +1926,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
+          "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -4620,9 +4620,9 @@
       }
     },
     "js-kinesis-sdk": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/js-kinesis-sdk/-/js-kinesis-sdk-0.9.9.tgz",
-      "integrity": "sha512-QMJkNheHZMYuLGHpA3fOWmssM8xn4TgSbekT8zhDQsVT5C0z7BGXvUEXmCkDvmCw61A5Sx3gt9hW+VxFhId4QA==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/js-kinesis-sdk/-/js-kinesis-sdk-0.9.10.tgz",
+      "integrity": "sha512-mrdEOmPIyq3VyQGPKmufNQgZ1nh058J1rincTRtxn5IhXWFgEY8wiFDJF40sNmtnzTIeaYfSoy+04/B0ga+CTg==",
       "requires": {
         "axios": "^0.12.0",
         "bluebird": "^3.1.5",
@@ -4665,9 +4665,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-xdr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-1.1.1.tgz",
-      "integrity": "sha512-csYOkKC78umSY2r3oDUONGH1ZcyTex7VlzpfmjKdzlNoeqFQtOA1rhBE9/e3mFNiO0Do65EVvyWx2jHHtRYPPg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-1.1.2.tgz",
+      "integrity": "sha512-ipiz1CnsyjLsba+QQd5jezGXddNKGa4oO9EODy0kWr3G3R8MNslIxkhQFpyRfY3yoY7YplhRVfC3cmXb4AobZQ==",
       "requires": {
         "core-js": "^2.6.3",
         "cursor": "^0.1.5",
@@ -4676,9 +4676,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
         }
       }
     },
@@ -8048,9 +8048,9 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "quote-stream": {
       "version": "1.0.2",
@@ -9607,11 +9607,11 @@
       }
     },
     "url-parse": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
-      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "requires": {
-        "querystringify": "^2.0.0",
+        "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "homepage": "https://github.com/KinesisNetwork/kinesis-explorer#readme",
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "0.18.0",
     "event-source-polyfill": "0.0.12",
-    "js-kinesis-sdk": "0.9.9",
+    "js-kinesis-sdk": "0.9.10",
     "lodash": "4.17.10",
     "moment": "2.22.1",
     "react": "16.3.2",


### PR DESCRIPTION
Update to the latest version of the `js-kinesis-sdk` npm package (`0.9.10`). This forces `https` for the multiple `operations` requests that we make when calculating the fee pool value, which was previously using `http` and being blocked by browsers.